### PR TITLE
Do not queue sessions missing TCP handshake

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -689,7 +689,7 @@ func (a *Assembler) AssembleWithContext(netFlow gopacket.Flow, t *layers.TCP, ac
 	if half.lastSeen.Before(timestamp) {
 		half.lastSeen = timestamp
 	}
-	a.start = half.nextSeq == invalidSequence && t.SYN
+	a.start = half.nextSeq == invalidSequence
 	if *debugLog {
 		if half.nextSeq < rev.ackSeq {
 			log.Printf("Delay detected on %v, data is acked but not assembled yet (acked %v, nextSeq %v)", key, rev.ackSeq, half.nextSeq)


### PR DESCRIPTION
TCP handshake can not be "out-of-order" - kernel will just drop
TCP packets coming without established connection - so we should
either also ignore them or consider that handshake happened (but
we missed it for some reason), there is no reason to hold such
session in reorder cache. Holding in reorder cache can cause
large memory consumption.